### PR TITLE
Shqip (Albanian Translation for Whos Online)

### DIFF
--- a/locale/sq.yml
+++ b/locale/sq.yml
@@ -1,0 +1,8 @@
+antoinefr-online:
+  forum:
+    title: Kush është në linjë ?
+  admin:
+    settings:
+      title: Cilësimet
+      displaymax: Numri i anëtareve që të shfaqen
+      titleoflist: Titulli që doni të shfaqni mbi listë


### PR DESCRIPTION
Albanian Language for the extension